### PR TITLE
fix for the case CPU + on_RAM=False

### DIFF
--- a/icu_benchmarks/data/loader.py
+++ b/icu_benchmarks/data/loader.py
@@ -146,6 +146,7 @@ class ICUVariableLengthLoaderTables(object):
             self.task_idx = task
             self.task = None
 
+        self.on_RAM = on_RAM
         # Processing the data part
         if self.data_h5.__contains__('data'):
             if on_RAM:  # Faster but comsumes more RAM


### PR DESCRIPTION
Fix regarding issue #9.
In the prior version running with parameter `on_RAM=False` and CPU hardware would lead to multiple workers accessing the original h5 file causing a decompression error. 
We now set `n_worker=1` in `DLWrapper` if `on_RAM=False` to avoid such issue.